### PR TITLE
Add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at opensource@expert360.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ following this guide:
 6. If everything looks good, push to your fork:
 
   ```bash
-  git push origin fix-mailchimp-pricing-bug
+  git push origin fix-nasty-bug
   ```
 
 7. [Submit a pull request.](https://help.github.com/articles/creating-a-pull-request)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to DAL
+
+Thanks for thinking about contributing to DAL. Please review this document
+first and also take a look at our [Code of Conduct](CODE_OF_CONDUCT.md), to
+help us keep this project inclusive to all those that may wish to contribute
+also.
+
+## Opening Issues
+
+We classify bugs as any unexpected behaviour that occurs based on the code in
+the project, and we really appreciate it when users take the time to [create an
+issue](https://github.com/expert360/dal/issues).
+
+Please take time to add as much detail as you can to any bug reports, consider
+including things like the version of Elixir you are using and any reproduction
+steps you can provide. The more context the better.
+
+If you are thinking about adding a feature, you should the check the
+[issues](https://github.com/expert360/dal/issues) first, someone else may have
+started already, or it might be a feature we've decided not to implement
+intentionally.
+
+## Submitting Pull Requests
+
+Whether you're fixing a bug, or proposing a feature you'd like to see included, you can submit Pull Requests by
+following this guide:
+
+1. [Fork this repository](https://github.com/expert360/dal/fork) and then clone it locally:
+
+  ```bash
+  git clone https://github.com/expert360/dal
+  ```
+
+2. Create a topic branch for your changes:
+
+  ```bash
+  git checkout -b fix-nasty-bug
+  ```
+
+3. Commit a failing test for the bug:
+
+  ```bash
+  git commit -am "Add a failing test that demonstrates the bug"
+  ```
+
+4. Commit a fix that makes the test pass:
+
+  ```bash
+  git commit -am "Fix nasty bug"
+  ```
+
+5. Run the tests:
+
+  ```bash
+  mix test
+  ```
+
+6. If everything looks good, push to your fork:
+
+  ```bash
+  git push origin fix-mailchimp-pricing-bug
+  ```
+
+7. [Submit a pull request.](https://help.github.com/articles/creating-a-pull-request)
+
+
+## Style guidelines
+
+We support the common conventions found in Elixir, if you're in doubt take a
+look at the code in the project, and we would like to keep the style consistent
+throughout.


### PR DESCRIPTION
Per the title; we'll need to confirm if this is the code of conduct we want to use (it's relatively common now for a few large projects, see [here](https://www.contributor-covenant.org/)). If so, we'll need to decide on the contact email address we want to use (I will point out the specific line in this PR).