### PR TITLE
Provide DAL.Sandbox helpers

### DIFF
--- a/lib/dal/sandbox.ex
+++ b/lib/dal/sandbox.ex
@@ -1,0 +1,27 @@
+defmodule DAL.Sandbox do
+  @moduledoc """
+  Helper module for dealing with Repo Sanboxes in tests.
+  """
+
+  alias Ecto.Adapters.SQL.Sandbox
+
+  @doc """
+  Checkout all provided repos in `:shared` mode.
+
+  ```
+  setup do
+    :ok = DAL.Sandbox.checkout_all_as_shared([A, B, C])
+  end
+  ```
+  """
+  def checkout_all_as_shared(repos) when is_list(repos) do
+    Enum.each(repos, fn repo ->
+      with :ok <- Sandbox.checkout(repo),
+           :ok <- Sandbox.mode(repo, {:shared, self()}) do
+        :ok
+      else
+        :error
+      end
+    end)
+  end
+end


### PR DESCRIPTION
This adds a module `DAL.Sandbox` with the helper
`checkout_all_as_shared` which, given a list of repos by module name
(atom) will check those repos out in `:shared` mode using `self()`. If
there are any unexpected values, we simply return `:error`, although it
might be nicer to make it the standard two-tuple as to provide a reason
for why the checkout has failed.