### PR TITLE
Provide DAL.Repo helpers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,14 @@ jobs:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
       - image: circleci/postgres:9.4
+        environment:
+          POSTGRES_DB: circle_test
+          POSTGRES_USER: root
     environment:
-      POSTGRES_USER: root
       POSTGRES_DB: circle_test
+      POSTGRES_USER: root
       POSTGRES_HOST: localhost
+      MIX_ENV: test
 
     working_directory: ~/repo
     steps:
@@ -30,7 +34,7 @@ jobs:
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get
-      - run: MIX_ENV=test mix do compile --warnings-as-errors, coveralls.json
+      - run: mix do compile --warnings-as-errors, coveralls.json
       - run:
           name: Running Inch CI documentation tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get
-      - run: mix do compile --warnings-as-errors, coveralls.json
+      - run: MIX_ENV=test mix do compile --warnings-as-errors, coveralls.json
       - run:
           name: Running Inch CI documentation tests
           command: |

--- a/lib/dal/repo.ex
+++ b/lib/dal/repo.ex
@@ -1,0 +1,92 @@
+defmodule DAL.Repo do
+  @moduledoc """
+  Helpers for introspecting on schemas and repos related to DAL usage
+  """
+
+  @doc """
+  Given an `app_name`, returns a unique list of repos that all schema
+  implementations point to. `app_name` is the same one would pass for your
+  `app:` key under your `project` definition in ones `mix.exs`. e.g.
+
+      defmodule MyProject.Mixfile do
+        def project do
+          [
+            app: my_project
+            <...snip...>
+          ]
+        end
+        <...snip...>
+      end
+
+  with a repo
+
+      defmodule MyProject.Repo.MyRepo do
+        use Ecto.Repo, otp_app: :my_project
+
+        <...snip...>
+      end
+
+  and an implementation
+
+      defmodule MyProject.Schema.MySchema do
+        <...snip...>
+
+        defimpl DAL.Repo.Discoverable do
+          def repo(_), do: MyProject.Repo.MyRepo
+        end
+      end
+
+  can be used as:
+
+      iex> DAL.Repo.repos(:my_project)
+      [MyProject.Repo.MyRepo]
+
+
+  This is particularly useful for tests where one may call
+
+      setup_all do
+        :ok = DAL.Sandbox.checkout_all_as_shared(DAL.Repo.repos(:my_project))
+      edn
+
+  """
+  def repos!(app_name) do
+    {:ok, rs} = repos(app_name)
+    rs
+  end
+
+  def repos(app_name) when is_atom(app_name) and not is_nil(app_name) do
+    with {:ok, ss} <- schemas(app_name) do
+      rs =
+        ss
+        |> Enum.map(fn s -> DAL.Repo.Discoverable.repo(struct(s)) end)
+        |> Enum.uniq
+
+       {:ok, rs}
+    else
+      err ->
+        err
+    end
+  end
+  def repos(_) do
+    {:error, "Invalid arguments passed to '#{__ENV__.function |> elem(0)}'"}
+  end
+
+  def schemas(app_name) when is_atom(app_name) and not is_nil(app_name) do
+    with path when is_list(path) <- :code.lib_dir(app_name, :ebin) do
+      ss =
+        DAL.Repo.Discoverable
+        |> Protocol.extract_impls([path])
+        |> Enum.uniq()
+
+      {:ok, ss}
+    else
+      {:error, :bad_name} ->
+        {:error, "No application found by the name '#{app_name}'"}
+      err ->
+        {:error, "An unknown error occured: #{inspect err}"}
+    end
+  end
+  def schemas(_) do
+    {:error, "Invalid arguments passed to '#{__ENV__.function |> elem(0)}'"}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Dal.MixProject do
     [
       app: :dal,
       name: "DAL",
-      version: "0.1.1",
+      version: "0.2.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Per the module doc, these allow one to provide their app name to the functions `repos` and `schemas` and get back all associated repos and schemas that have implementations under `DAL`. 

I have not included any tests for this besides some examples in the doc. Let me know if you'd like some and I can rig those up.